### PR TITLE
Fix builds for external PRs, closes #62

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,8 @@ deploy:
   on:
     branch: master
 before_install:
-  - openssl aes-256-cbc -K $encrypted_bb8f495d020f_key -iv $encrypted_bb8f495d020f_iv
-    -in app-engine-secret.json.enc -out app-engine-secret.json -d
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+      openssl aes-256-cbc -K $encrypted_bb8f495d020f_key -iv $encrypted_bb8f495d020f_iv \
+        -in app-engine-secret.json.enc -out app-engine-secret.json -d
+    fi


### PR DESCRIPTION
Pull requests builds don't deploy to GAE, so there's no need to try to
decrypt the secrets, which doesn't work for external PRs since travis
doesn't provide the encryption key.