### PR TITLE
Capitalizing React component's name

### DIFF
--- a/frontend/app/forms/consent-and-waiver-of-hearing/consent-and-waiver-of-hearing.pdf.component.js
+++ b/frontend/app/forms/consent-and-waiver-of-hearing/consent-and-waiver-of-hearing.pdf.component.js
@@ -7,7 +7,7 @@ import {
   getCounty
 } from "../form-common-options/form-common-options";
 
-export default function consentAndWaiverOfHearing_Pdf({ data, renderData }) {
+export default function ConsentAndWaiverOfHearing_Pdf({ data, renderData }) {
   return (
     <>
       <RenderPage url="/static/forms/consent-and-waiver-of-hearing/consent-and-waiver-of-hearing-1.png">


### PR DESCRIPTION
React component functions should be capitalized. It's actually required to do so if your component is a named export from the file because JSX requires capital letters for react components. However, for default exported components it isn't required because it gets renamed when the person imports it. However, it's just a really strong convention in the React community to do this anyway, so I am creating this PR to fix it.