### PR TITLE
coversheet: adds radio button to check for attorney

### DIFF
--- a/frontend/app/forms/coversheet/coversheet.web.component.js
+++ b/frontend/app/forms/coversheet/coversheet.web.component.js
@@ -2,12 +2,15 @@ import React from "react";
 import { Scoped } from "kremling";
 import TextInput from "../inputs/text-input.component.js";
 import Select from "../inputs/select.component.js";
+import Radio from "../inputs/radio.component.js";
 import TextArea from "../inputs/text-area.component.js";
 import FormThatPrints from "../inputs/form-that-prints.component.js";
 import Section from "../inputs/section.component.js";
 
 export default class Coversheet_Web extends React.Component {
   render() {
+    const { data } = this.props;
+
     return (
       <Scoped css={css}>
         <FormThatPrints>
@@ -22,14 +25,27 @@ export default class Coversheet_Web extends React.Component {
 
             <TextInput dataKey="person.homePhone" label="Home Phone Number" />
             <TextInput dataKey="person.email" label="Email" />
-            <TextInput
-              dataKey="person.petitionerAttorneyName"
-              label="Attorney Name"
+
+            <Radio
+              dataKey="coversheet.isAttorney"
+              label="Is an attorney filling out the form"
+              options={[
+                { label: "Yes", value: "yes" },
+                { label: "No", value: "no" }
+              ]}
             />
-            <TextInput
-              dataKey="person.petitionerBarNumber"
-              label="Attorney Bar Number"
-            />
+            {data.coversheet && data.coversheet.isAttorney === "yes" && (
+              <>
+                <TextInput
+                  dataKey="person.petitionerAttorneyName"
+                  label="Attorney Name"
+                />
+                <TextInput
+                  dataKey="person.petitionerBarNumber"
+                  label="Attorney Bar Number"
+                />
+              </>
+            )}
           </Section>
         </FormThatPrints>
       </Scoped>

--- a/frontend/app/forms/coversheet/coversheet.web.component.js
+++ b/frontend/app/forms/coversheet/coversheet.web.component.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Scoped } from "kremling";
+import { petitionerRepresentativeOptions } from "../form-common-options/form-common-options";
 import TextInput from "../inputs/text-input.component.js";
 import Select from "../inputs/select.component.js";
 import Radio from "../inputs/radio.component.js";
@@ -28,13 +29,10 @@ export default class Coversheet_Web extends React.Component {
 
             <Radio
               dataKey="coversheet.isAttorney"
-              label="Is an attorney filling out the form"
-              options={[
-                { label: "Yes", value: "yes" },
-                { label: "No", value: "no" }
-              ]}
+              label="Are you the petitioner?"
+              options={petitionerRepresentativeOptions}
             />
-            {data.coversheet && data.coversheet.isAttorney === "yes" && (
+            {data.coversheet && data.coversheet.isAttorney === "attorney" && (
               <>
                 <TextInput
                   dataKey="person.petitionerAttorneyName"


### PR DESCRIPTION
Addresses: https://github.com/JustUtahCoders/utahexpungements.org/issues/25 

Specifically this request from @tuckersamuelsen :

>  I think it might be useful to have a radio before the Attorney part. Basically just ask if an attorney is filling it out for them, and if they say yes than ask for attorney name and bar number. I can see it being confusing if a person is on their own, not knowing what to put.