### PR TITLE
Add wait time for Busboy in parse-docket-pdf api (#101)

### DIFF
--- a/backend/apis/parse-docket-pdf.api.js
+++ b/backend/apis/parse-docket-pdf.api.js
@@ -7,6 +7,7 @@ app.post("/api/docket-pdfs", (req, res) => {
   let busboy;
   try {
     busboy = new Busboy({ headers: req.headers });
+    busboy.highWaterMark = 2 * 1024 * 1024; // Set 2MiB buffer
   } catch (err) {
     console.error(err);
     res.status(400).send({ error: err.message });
@@ -59,3 +60,15 @@ app.post("/api/docket-pdfs", (req, res) => {
 
   return req.pipe(busboy);
 });
+
+function retryBusboy(data, remainingAttempts) {
+  //console.log('retrying', remainingAttempts)
+  const promise = pdf(data);
+  return promise.catch(err => {
+    if (remainingAttempts > 0) {
+      return retryExtractPdfText(data, remainingAttempts - 1);
+    } else {
+      throw err;
+    }
+  });
+}

--- a/backend/apis/parse-docket-pdf.api.js
+++ b/backend/apis/parse-docket-pdf.api.js
@@ -60,15 +60,3 @@ app.post("/api/docket-pdfs", (req, res) => {
 
   return req.pipe(busboy);
 });
-
-function retryBusboy(data, remainingAttempts) {
-  //console.log('retrying', remainingAttempts)
-  const promise = pdf(data);
-  return promise.catch(err => {
-    if (remainingAttempts > 0) {
-      return retryExtractPdfText(data, remainingAttempts - 1);
-    } else {
-      throw err;
-    }
-  });
-}


### PR DESCRIPTION
Added wait time (highWaterMark: 2MiB buffer) for large files to process through Busboy (parse incoming HTML form data)
Fixed example problem: file with 33KB would sometimes not parse, and now it 99% does parse.