### PR TITLE
hide side menu scroll bar when not in use

### DIFF
--- a/frontend/navbar/menu-items.component.js
+++ b/frontend/navbar/menu-items.component.js
@@ -130,6 +130,6 @@ const css = `
   }
 
   & .side-menu.off-screen {
-    left: -27.5rem;
+    left: -29.5rem;
   }
 `;


### PR DESCRIPTION
scroll bar was sticking out when the sidebar wasn't open