### PR TITLE
first cut of isConviction util fn

### DIFF
--- a/backend/apis/flag-utils/is-conviction.util.js
+++ b/backend/apis/flag-utils/is-conviction.util.js
@@ -1,0 +1,14 @@
+exports.isConviction = function(parsedObj) {
+  if (containsDisposition(parsedObj)) {
+    return false;
+  }
+  // TODO: check if dismissed or transferred
+};
+
+function containsDisposition(parsedObj) {
+  return parsedObj.charges
+    .map(charge => {
+      return charge.hasOwnProperty("disposition");
+    })
+    .includes(false);
+}


### PR DESCRIPTION
First cut of utility function for checking if docket has conviction or not. This PR adds check for whether docket has `disposition` property or not. If charges do not have disposition field, it is very likely that the case is still pending and does not qualify for expungements.