### PR TITLE
added child abuse flag, added engines field to package.json

### DIFF
--- a/backend/apis/flag-utils/is-child-abuse.js
+++ b/backend/apis/flag-utils/is-child-abuse.js
@@ -1,0 +1,11 @@
+exports.isChildAbuse = function isChildAbuse(parsedObj) {
+  let containsChildAbuse = false;
+
+  parsedObj.charges.forEach(charge => {
+    if (charge.offenseName.toLowerCase().includes("child")) {
+      containsChildAbuse = true;
+    }
+  });
+
+  return containsChildAbuse;
+};

--- a/backend/apis/generate-flag-json.utils.js
+++ b/backend/apis/generate-flag-json.utils.js
@@ -4,12 +4,14 @@ const {
 } = require("./flag-utils/is-drug-conviction-flag-util");
 const { isDebtCollection } = require("./flag-utils/is-debt-collection-util");
 const { isAutomobileHomicide } = require("./flag-utils/is-automobile-homicide");
+const { isChildAbuse } = require("./flag-utils/is-child-abuse");
 
 exports.generateFlagJson = function generateFlagJson(parsedObj) {
   return {
     isClassBMisdemeanor: isClassBMisdemeanor(parsedObj),
     isDrugPosessionOffense: isDrugPosessionOffense(parsedObj),
     isDebtCollection: isDebtCollection(parsedObj),
-    isAutomobileHomicide: isAutomobileHomicide(parsedObj)
+    isAutomobileHomicide: isAutomobileHomicide(parsedObj),
+    isChildAbuse: isChildAbuse(parsedObj)
   };
 };

--- a/backend/apis/parse-docket-pdf.api.js
+++ b/backend/apis/parse-docket-pdf.api.js
@@ -33,8 +33,8 @@ app.post("/api/docket-pdfs", (req, res) => {
             const processJson = req.query.processJson === "true" ? true : false;
             if (processJson) {
               //comment this back in if you want to test flag json
-              //res.send(generateFlagJson(parsePdfText(thePdf.text)));
-              res.send(parsePdfText(thePdf.text));
+              res.send(generateFlagJson(parsePdfText(thePdf.text)));
+              // res.send(parsePdfText(thePdf.text));
             } else {
               res.send(thePdf.text);
             }

--- a/frontend/app/forms/bank/filtered-forms.component.js
+++ b/frontend/app/forms/bank/filtered-forms.component.js
@@ -24,9 +24,10 @@ export default class FilteredForms extends React.Component {
     }
   }
   recreateFuseSearch() {
-    const reactChildren = React.Children.toArray(this.props.children).filter(
-      child =>
-        this.props.showIncompleteForms ? true : child.props.readyForUsers
+    const reactChildren = React.Children.toArray(
+      this.props.children
+    ).filter(child =>
+      this.props.showIncompleteForms ? true : child.props.readyForUsers
     );
 
     this.setState({

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "repository": "git@github.com:UtahAccessToJustice/utahexpungements.org.git",
   "author": "Joel Denning <joel.denning@canopytax.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=8.3.0"
+  },
   "scripts": {
     "webpack": "webpack --config webpack.config.js",
     "start": "node backend/server.js",


### PR DESCRIPTION
I had to add "engines" field in package.json due to the following error on line 90 in parse-docket.pdf.utils.js

> Rest/spread properties are not supported until Node.js 8.3.0.

