### PR TITLE
support for handling multiple file uploads

### DIFF
--- a/backend/apis/parse-docket-pdf.api.js
+++ b/backend/apis/parse-docket-pdf.api.js
@@ -6,7 +6,12 @@ const { generateFlagJson } = require("./generate-flag-json.utils");
 
 app.post("/api/docket-pdfs", (req, res) => {
   let busboy;
-  const busBoyConfig = { headers: req.headers };
+  const busBoyConfig = {
+    headers: req.headers,
+    limits: {
+      fileSize: 10
+    }
+  };
 
   try {
     busboy = new Busboy(busBoyConfig);

--- a/frontend/app/docket-pdf/docket-pdf.component.js
+++ b/frontend/app/docket-pdf/docket-pdf.component.js
@@ -53,6 +53,7 @@ export default function DocketPdf(props) {
             name="docket-pdf"
             type="file"
             accept=".pdf"
+            multiple
             required
             onChange={newFile}
           />


### PR DESCRIPTION
It's not pretty, but it's working. Feedback welcome. We may also want to set a limit on number of files.

currently payload looks like:
```
[{"caseNumber": "123" ...}, {"caseNumber": "124" ...}]
```
should we change the payload to have some indication of what parsed data belongs to which docket? something like this? 
```
[{"fileName": "docket.pdf", "caseNumber": "123" ...}, {"fileName": "docket_1.pdf", "caseNumber": "124" ...}]
```