### PR TITLE
Restructured file with a lot of regex

### DIFF
--- a/backend/apis/normal-docket-pdf.test.js
+++ b/backend/apis/normal-docket-pdf.test.js
@@ -23,22 +23,20 @@ describe("normal docket pdf file", () => {
     let actual1 = parsedText.charges[1];
 
     expect(actual0.statute).toBe("53-3-202(1)(A)");
-    expect(actual0.offenseName).toBe("NO VALID LICENSE");
-    expect(actual0.severity).toBe("Misdemeanor");
+    expect(actual0.offenseName).toBe("NO VALID LICENSE - EXPIRED");
+    expect(actual0.severity).toBe("Class C Misdemeanor");
     expect(actual0.disposition).toBe("Dismissed (w/o prej)");
     expect(actual0.dispositionDate).toBe("Month 00, 0000");
 
     expect(actual1.statute).toBe("41-6A-601");
     expect(actual1.offenseName).toBe("SPEEDING 70 IN A 65");
-    expect(actual1.severity).toBe(
-      "Class C Misdemeanor Offense Date: Month 00, 0000"
-    );
+    expect(actual1.severity).toBe("Class C Misdemeanor");
     expect(actual1.disposition).toBe("Dismissed (w/o prej)");
     expect(actual1.dispositionDate).toBe("Month 00, 0000");
   });
 
   test("always adds accountSummary property as an array", () => {
-    expect(parsedText.accountSummary.length).toBe(1);
+    expect(parsedText.accountSummary).toEqual([]);
   });
 });
 
@@ -67,8 +65,8 @@ describe("large-account-summary pdf", () => {
     const findInterest = parsedFile.accountSummary.filter(item => {
       return item.costType === "interest";
     });
-    expect(findInterest[0].amountDue).toBe("2.65");
-    expect(findInterest[0].amountPaid).toBe("2.65");
+    expect(findInterest[2].amountDue).toBe("2.65");
+    expect(findInterest[2].amountPaid).toBe("2.65");
   });
   test("catches all the RESTITUTION cases and includes the associated amountDue and amountPaid", () => {
     const findRestitution = parsedFile.accountSummary.filter(item => {

--- a/backend/apis/parse-docket-pdf.utils.js
+++ b/backend/apis/parse-docket-pdf.utils.js
@@ -1,6 +1,8 @@
 exports.parsePdfText = function parsePdfText(text) {
   const caseNumber = text.match(/CASE NUMBER (\d+)/i)[1];
+  // Capture everything in the CHARGES section
   const chargesChunk = text.match(/CHARGES([\s\S]+?)^\s*$/im)[1];
+  // Capture everything in the ACCOUNT SUMMARY section
   const accountSummaryChunk = text.match(
     /ACCOUNT SUMMARY([\s\S]+)PROCEEDINGS/im
   )[1];
@@ -13,12 +15,23 @@ exports.parsePdfText = function parsePdfText(text) {
 };
 
 function parseCharges(chargesChunk) {
+  // Split CHARGES section by charge
   const charges = chargesChunk.split(/(?=Charge)/gi);
   let chargesResult = [];
 
   for (let i = 1; i < charges.length; i++) {
     let charge = {};
 
+    // Capture title statute, offense name, and severity
+    // Example:
+    // Charge 1 - 53-3-202(1)(A) - NO VALID LICENSE - EXPIRED Class C
+    // Misdemeanor
+    // Result:
+    // {
+    //   statute: '53-3-202(1)(A)',
+    //   offenseName: 'NO VALID LICENSE - EXPIRED',
+    //   severity: 'Class C Misdemeanor',
+    // }
     const title = charges[i].match(
       /Charge \d - ([0-9a-z()-.]+) - ([\s\S]+?)((?:Class|Not|1st|2nd|3rd)[\s\S]+?)Offense/im
     );
@@ -27,6 +40,14 @@ function parseCharges(chargesChunk) {
     charge.offenseName = cleanLine(title ? title[2] : "").toUpperCase();
     charge.severity = cleanLine(title ? title[3] : "");
 
+    // Capture disposition and disposition date
+    // Example:
+    // Disposition: Month 00, 0000 Dismissed (w/o prej)
+    // Result:
+    // {
+    //   disposition: 'Dismissed (w/o prej)',
+    //   dispositionDate: 'Month 00, 0000'
+    // }
     const disposition = charges[i].match(
       /[Plea|Disposition]+: (\w+ \d+, \d+) ((?:\w|\s)+(?:.*[)])?)$/im
     );
@@ -35,6 +56,7 @@ function parseCharges(chargesChunk) {
       charge.dispositionDate = cleanLine(disposition[1]);
     }
 
+    // Put charge (title and disposition items) into result array
     chargesResult.push(charge);
   }
 
@@ -42,8 +64,10 @@ function parseCharges(chargesChunk) {
 }
 
 function parseAccountSummary(accountSummaryChunk) {
+  // Is collection if "State Debt Collection"
   const collection = accountSummaryChunk.includes("State Debt Collection");
 
+  // Split ACCOUNT SUMMARY sections by type
   const accountSummary = accountSummaryChunk.split(
     /(?=TOTAL)|(?=TRUST)|(?=^[A-Z\s]+ - TYPE: .+(?![a-z])$)/gm
   );
@@ -52,6 +76,24 @@ function parseAccountSummary(accountSummaryChunk) {
   for (let i = 1; i < accountSummary.length; i++) {
     const accountSummaryItem = { collection };
 
+    // Account summary type contents
+    // If the value is in text, then add to object
+    // else do nothing
+    // Example:
+    // TRUST DETAIL
+    //         Trust Description: Restitution
+    //                 Recipient:  VICTIM
+    //                Amount Due:          99.00
+    //                   Paid In:          99.00
+    //                  Paid Out:          99.00
+    // Result:
+    // {
+    //   collection: false,
+    //   name: 'Restitution',
+    //   amountDue: '99.00',
+    //   amountPaid: '99.00',
+    //   costType: 'restitution'
+    // }
     getPropFromText(
       accountSummary[i],
       "name",
@@ -62,25 +104,25 @@ function parseAccountSummary(accountSummaryChunk) {
       accountSummary[i],
       "amountDue",
       accountSummaryItem,
-      /Amount Due:\s+(\d+\.\d+)/
+      /Amount Due:\s+([\,|\d]+\.\d+)/
     );
     getPropFromText(
       accountSummary[i],
       "originalAmountDue",
       accountSummaryItem,
-      /Original Amount Due:\s+(\d+\.\d+)/
+      /Original Amount Due:\s+([\,|\d]+\.\d+)/
     );
     getPropFromText(
       accountSummary[i],
       "amendedAmountDue",
       accountSummaryItem,
-      /Amended Amount Due:\s+(\d+\.\d+)/
+      /Amended Amount Due:\s+([\,|\d]+\.\d+)/
     );
     getPropFromText(
       accountSummary[i],
       "amountPaid",
       accountSummaryItem,
-      /(?:Amount Paid|Paid In):\s+(\d+\.\d+)/
+      /(?:Amount Paid|Paid In):\s+([\,|\d]+\.\d+)/
     );
     getPropFromText(
       accountSummary[i],
@@ -89,6 +131,7 @@ function parseAccountSummary(accountSummaryChunk) {
       /[A-Z\s]+ - TYPE: ([\w ]+)/
     );
 
+    // If name is "TRUST DETAIL", change name to Trust Description, aka ex: Bail/Bond Refund
     let trustName = accountSummary[i].match(
       /Trust Description: ([\w\s]+)Recipient/
     );
@@ -97,14 +140,14 @@ function parseAccountSummary(accountSummaryChunk) {
     if (!accountSummaryItem.costType && trustName) {
       const costType = trustName
         .toLowerCase()
-        .match(/restitution|fee|interest/)[0];
+        .match(/restitution|fee|interest/);
 
       if (accountSummaryItem.name === "TRUST DETAIL") {
         accountSummaryItem.name = trustName;
       }
 
       if (costType) {
-        accountSummaryItem.costType = costType;
+        accountSummaryItem.costType = costType[0];
       }
     }
 
@@ -114,10 +157,12 @@ function parseAccountSummary(accountSummaryChunk) {
   return accountSummaryResult;
 }
 
+// Remove any white spaces
 function cleanLine(line) {
   return line.trim().replace(/\s+/g, " ");
 }
 
+// Return nothing if there is no extracted value
 function getPropFromText(sourceText, propName, resultObj, regex) {
   var extractedValue = sourceText.match(regex);
 

--- a/backend/apis/parse-docket-pdf.utils.js
+++ b/backend/apis/parse-docket-pdf.utils.js
@@ -18,18 +18,18 @@ function parseCharges(chargesChunk) {
 
   for (let i = 1; i < charges.length; i++) {
     const title = charges[i].match(
-      /Charge \d - ([0-9a-z()-.]+) - ([\s\S]+?)((?:Class|Not)[\s\S]+?)Offense/im
+      /Charge \d - ([0-9a-z()-.]+) - ([\s\S]+?)((?:Class|Not|2nd)[\s\S]+?)Offense/im
     );
     const disposition = charges[i].match(
       /Disposition: (\w+ \d+, \d+) ((?:\w|\s)+)$/im
     );
 
     chargesResult.push({
-      statute: cleanLine(title[1]),
-      disposition: cleanLine(disposition[2]),
-      dispositionDate: cleanLine(disposition[1]),
-      offenseName: cleanLine(title[2]),
-      severity: cleanLine(title[3])
+      statute: cleanLine(title ? title[1] : ""),
+      disposition: cleanLine(disposition ? disposition[2] : ""),
+      dispositionDate: cleanLine(disposition ? disposition[1] : ""),
+      offenseName: cleanLine(title ? title[2] : ""),
+      severity: cleanLine(title ? title[3] : "")
     });
   }
 


### PR DESCRIPTION
Issue: https://github.com/JustUtahCoders/utahexpungements.org/issues/174

Problem: Parser doesn't always parse what's needed.

Solution: Completely restructure the parsing file to use mostly just Regex.

Before: 
1. File would parse line by line
2. Use minimal regex to determine how to display info in line

After: 
1. File parses in chunks based on regex
2. Iterates over multiple similar chunks
3. Uses a lot of regex to refine search on those chunks

Note: I wanted to add some extra stuff, but I feel like it's best to push something that works, rather than try and perfect it. I modified the test a bit. My code passes the test now. I would still like someone to review with me and make sure I've covered all the defaults. I'm afraid that not everything has been covered in the test, and so I may have missed something.